### PR TITLE
Bulk Discount Delete Button

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -19,6 +19,12 @@ class BulkDiscountsController < ApplicationController
     redirect_to merchant_bulk_discounts_path(merchant.id)
   end
 
+  def destroy
+    bulk_discount = BulkDiscount.destroy(params[:id])
+
+    redirect_to merchant_bulk_discounts_path(params[:merchant_id])
+  end
+
   private
 
   def bulk_discount_params

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -9,5 +9,6 @@
       <li>Threshold: <%= bd.threshold %></li>
       <li>Percent Discount: <%= bd.percent_discount %></li>
     </ul>
+    <%= link_to 'Delete Discount', merchant_bulk_discount_path(@merchant.id, bd.id), method: :delete %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,6 @@ Rails.application.routes.draw do
     resources :items, only: [:index, :show, :update, :edit, :new, :create]
     resources :invoices, only: [:index, :show, :update]
     resources :dashboard, only: [:index]
-    resources :bulk_discounts, only: [:index, :show, :new, :create]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
   end
 end

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -69,5 +69,49 @@ RSpec.describe 'Merchant Bulk Discounts Index Page', type: :feature do
 
       expect(current_path).to eq(new_merchant_bulk_discount_path(merchant_1.id))
     end
+
+    context 'I see a delete link' do
+      scenario 'Next to each bulk discount is a link to delete it' do
+        within "#bulk-discount-#{fifteen_off_ten.id}" do
+          expect(page).to have_link('Delete Discount', href: merchant_bulk_discount_path(merchant_1.id, fifteen_off_ten.id))
+        end
+
+        within "#bulk-discount-#{twenty_off_fifteen.id}" do
+          expect(page).to have_link('Delete Discount', href: merchant_bulk_discount_path(merchant_1.id, twenty_off_fifteen.id))
+        end
+      end
+
+      scenario 'When I click this link it redirectws to the index page and the discount is no longer listed' do
+        expect(page).to have_content(fifteen_off_ten.name)
+        expect(page).to have_content(twenty_off_fifteen.name)
+
+        within "#bulk-discount-#{fifteen_off_ten.id}" do
+          click_link 'Delete Discount'
+        end
+
+        expect(current_path).to eq(merchant_bulk_discounts_path(merchant_1.id))
+        expect(page).to have_no_content(fifteen_off_ten.name)
+        expect(page).to have_content(twenty_off_fifteen.name)
+
+        within "#bulk-discount-#{twenty_off_fifteen.id}" do
+          click_link 'Delete Discount'
+        end
+
+        expect(current_path).to eq(merchant_bulk_discounts_path(merchant_1.id))
+        expect(page).to have_no_content(fifteen_off_ten.name)
+        expect(page).to have_no_content(twenty_off_fifteen.name)
+      end
+    end
+
+    #   No. 4 Merchant Bulk Discount Delete
+    #
+    # As a merchant
+    # When I visit my bulk discounts index
+    # Then next to each bulk discount I see a link to delete it
+    # When I click this link
+    # Then I am redirected back to the bulk discounts index page
+    # And I no longer see the discount listed
   end
+
+
 end

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -102,16 +102,5 @@ RSpec.describe 'Merchant Bulk Discounts Index Page', type: :feature do
         expect(page).to have_no_content(twenty_off_fifteen.name)
       end
     end
-
-    #   No. 4 Merchant Bulk Discount Delete
-    #
-    # As a merchant
-    # When I visit my bulk discounts index
-    # Then next to each bulk discount I see a link to delete it
-    # When I click this link
-    # Then I am redirected back to the bulk discounts index page
-    # And I no longer see the discount listed
   end
-
-
 end


### PR DESCRIPTION
Features:
- Add discount delete link to merchant's bulk discounts index page
- When clicked, link destroys the discount in the database and redirects to the index page

Updates:
- Add routes to destroy action in bulk_discounts controller

Tests:
- Add tests to cover button existence and behavior to bulk_discount/index_spec
- Features at 99.9%, Models at 100% coverage.