### PR TITLE
Merchant Invoice Show Page: Invoice Item Displays Applied Bulk Discount

### DIFF
--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -13,6 +13,12 @@ class InvoiceItem < ApplicationRecord
   has_many :bulk_discounts, through: :item
 
   def self.revenue
-      sum('quantity * unit_price')
+    sum('quantity * unit_price')
+  end
+
+  def find_bulk_discount
+    bulk_discounts.where("bulk_discounts.threshold <= ?", quantity)
+    .order(percent_discount: :desc)
+    .first
   end
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -17,6 +17,13 @@
       <p>Quantity: <%= invoice_item.quantity %> </p>
       <p>Unit Price: $<%= invoice_item.unit_price.to_f/100 %> </p>
       <p>Invoice Status: <%= invoice_item.status %> </p>
+
+      <% if invoice_item.find_bulk_discount != nil %>
+        <p>Bulk Discount: <%= link_to invoice_item.find_bulk_discount.name, merchant_bulk_discount_path(@merchant.id, invoice_item.find_bulk_discount.id) %></p>
+      <% else %>
+        <p>Bulk Discount: None</p>
+      <% end %>
+
       <p> <%= form_with url: merchant_invoice_path(item.merchant_id, @invoice.id), method: :patch, local: true do |f| %>
         <%= f.hidden_field :invoice_item_id, value: invoice_item.id %>
         <%= f.label :status, "Status"  %>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -152,5 +152,24 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
 
       expect(page).to have_content(total_merchant_discounted_revenue.to_f/100)
     end
+
+    scenario 'next to each invoice item I see a link to the bulk discount show page that was applied if any' do
+      save_and_open_page
+      within "#item#{item_1.id}" do
+        expect(page).to have_link(bulk_discount_1.name, href: merchant_bulk_discount_path(merchant_1.id, bulk_discount_1.id))
+        expect(page).to have_no_content('None')
+      end
+
+      within "#item#{item_2.id}" do
+        expect(page).to_not have_link(bulk_discount_1.name, href: merchant_bulk_discount_path(merchant_1.id, bulk_discount_1.id))
+        expect(page).to have_content("None")
+      end
+    end
   end
+
+#   No. 8 Merchant Invoice Show Page: Link to applied discounts
+#
+# As a merchant
+# When I visit my merchant invoice show page
+# Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -38,4 +38,22 @@ RSpec.describe InvoiceItem do
       end
     end
   end
+
+  describe 'instance methods' do
+    describe '#find_bulk_discount' do
+      it 'returns the bulk discount with the highest percentage if there is one for an invoice item' do
+        invoice_2 = customer_1.invoices.create!(status: 1, created_at: '2012-03-25 09:54:09')
+
+        invoice_item_4 = InvoiceItem.create!(quantity: 11, unit_price: item_1.unit_price, item_id: item_1.id, invoice_id: invoice_2.id, status: 0)
+        invoice_item_5 = InvoiceItem.create!(quantity: 1, unit_price: item_1.unit_price, item_id: item_1.id, invoice_id: invoice_2.id, status: 0)
+
+        bulk_discount_1 = merchant_1.bulk_discounts.create!(name: 'Ten off Ten', threshold: 10, percent_discount: 10)
+
+
+        expect(invoice_item_4.find_bulk_discount).to eq(bulk_discount_1)
+
+        expect(invoice_item_5.find_bulk_discount).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe InvoiceItem do
 
         expect(invoice_item_5.find_bulk_discount).to eq(nil)
       end
+
+      it 'returns the highest percentage discount when more than one applies' do
+        invoice_2 = customer_1.invoices.create!(status: 1, created_at: '2012-03-25 09:54:09')
+
+        invoice_item_4 = InvoiceItem.create!(quantity: 11, unit_price: item_1.unit_price, item_id: item_1.id, invoice_id: invoice_2.id, status: 0)
+        invoice_item_5 = InvoiceItem.create!(quantity: 6, unit_price: item_1.unit_price, item_id: item_1.id, invoice_id: invoice_2.id, status: 0)
+
+        bulk_discount_1 = merchant_1.bulk_discounts.create!(name: 'Ten off Ten', threshold: 10, percent_discount: 10)
+        bulk_discount_2 = merchant_1.bulk_discounts.create!(name: 'Five off Five', threshold: 5, percent_discount: 5)
+
+        expect(invoice_item_4.find_bulk_discount).to eq(bulk_discount_1)
+        expect(invoice_item_5.find_bulk_discount).to eq(bulk_discount_2)
+      end
     end
   end
 end


### PR DESCRIPTION
Feature:
- The invoice items on a merchant invoice show page have a section that shows the bulk discount applied to the item if any
- If a bulk discount has been applied the name is a link to that discount show page
- If no bulk discount is applied it displays "none" in the section
- For items with more than one applicable bulk discount it displays only the one with the highest discount percentage

Models:
- Add #find_bulk_discount instance method to invoice_items  model

Tests:
- Test display of invoice_item bulk discount on invoice show page
- Test display of bulk_discount when there is none
- Model tests for #find_bulk_discount
- Feature Test Coverage: 99.91%
- Model Test Coverage: 100.00%