### PR TITLE
Admin Invoice Show Page: Display Total Discounted Revenue

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
 
-  def github_facade
-    @github_facade = GithubFacade.new
-  end
+  # def github_facade
+  #   @github_facade = GithubFacade.new
+  # end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -27,11 +27,19 @@ class Invoice < ApplicationRecord
   end
 
   def total_discounts_by_merchant(merchant_id)
-    # require "pry"; binding.pry
     invoice_items.joins(:bulk_discounts)
                  .select("invoice_items.id, max(invoice_items.unit_price * invoice_items.quantity * (bulk_discounts.percent_discount / 100.00)) as total_discount")
                  .where("invoice_items.quantity >= bulk_discounts.threshold")
                  .where("bulk_discounts.merchant_id = ?", merchant_id)
+                 .group("invoice_items.id")
+                 .order("total_discount desc")
+                 .sum(&:"total_discount")
+  end
+
+  def total_invoice_discounts
+    invoice_items.joins(:bulk_discounts)
+                 .select("invoice_items.id, max(invoice_items.unit_price * invoice_items.quantity * (bulk_discounts.percent_discount / 100.00)) as total_discount")
+                 .where("invoice_items.quantity >= bulk_discounts.threshold")
                  .group("invoice_items.id")
                  .order("total_discount desc")
                  .sum(&:"total_discount")

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -21,3 +21,4 @@
 <% end %>
 <br>
 <h3> Total Revenue: $<%= @invoice.invoice_items.revenue.to_f/100 %> </h3>
+<h3> Total Discounted Revenue: $<%= (@invoice.invoice_items.revenue.to_f/100) - (@invoice.total_invoice_discounts.to_f/100) %> </h3>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -15,53 +15,87 @@ RSpec.describe 'Admin Invoice Show page' do
   let!(:invoice_item_2)  {InvoiceItem.create!(item_id: item_2.id, invoice_id: invoice_1.id, unit_price: item_2.unit_price, quantity: 26, status: 0)}
   let!(:invoice_item_3)  {InvoiceItem.create!(item_id: item_3.id, invoice_id: invoice_1.id, unit_price: item_3.unit_price, quantity: 2, status: 0)}
 
+  let!(:bulk_discount_1) {merchant_1.bulk_discounts.create!(name: "Ten off Ten", threshold: 10, percent_discount: 10)}
+
   before(:each) do
     visit admin_invoice_path(invoice_1.id)
   end
 
-  scenario 'admin sees invoice attributes' do
-    expect(page).to have_content(invoice_1.id)
-    expect(page).to have_content(invoice_1.creation_date_formatted)
-    expect(page).to have_content(customer_1.first_name)
-    expect(page).to have_content(customer_1.last_name)
-  end
+  context 'When an admin visits the admin invoice show page' do
+    scenario 'admin sees invoice attributes' do
+      expect(page).to have_content(invoice_1.id)
+      expect(page).to have_content(invoice_1.creation_date_formatted)
+      expect(page).to have_content(customer_1.first_name)
+      expect(page).to have_content(customer_1.last_name)
+    end
 
-  scenario 'admin sees all items on invoice' do
-    expect(page).to have_content(item_1.name)
-    expect(page).to have_content(item_1.unit_price.to_f/100)
-    expect(page).to have_content(invoice_item_1.quantity)
-    expect(page).to have_content(invoice_item_3.status)
-  end
+    scenario 'admin sees all items on invoice' do
+      expect(page).to have_content(item_1.name)
+      expect(page).to have_content(item_1.unit_price.to_f/100)
+      expect(page).to have_content(invoice_item_1.quantity)
+      expect(page).to have_content(invoice_item_3.status)
+    end
 
-  scenario 'visitor sees invoice status is a select field next to invoice with current status selected' do
-    expect(page).to have_field('status', with: 'completed')
-    expect(page).to have_button('Update Invoice Status')
-  end
+    context 'there is an invoice item status field' do
+      scenario 'visitor sees invoice status is a select field next to invoice with current status selected' do
+        expect(page).to have_field('status', with: 'completed')
+        expect(page).to have_button('Update Invoice Status')
+      end
 
-  scenario 'visitor can select new status and update by clicking submit button' do
-    expect(page).to have_field('status', with: 'completed')
-    expect(page).to have_button('Update Invoice Status')
+      scenario 'visitor can select new status and update by clicking submit button' do
+        expect(page).to have_field('status', with: 'completed')
+        expect(page).to have_button('Update Invoice Status')
 
-    select 'Cancelled', from: 'status'
-    click_button('Update Invoice Status')
+        select 'Cancelled', from: 'status'
+        click_button('Update Invoice Status')
 
-    expect(current_path).to eq(admin_invoice_path(invoice_1.id))
-    expect(page).to have_field('status', with: 'cancelled')
+        expect(current_path).to eq(admin_invoice_path(invoice_1.id))
+        expect(page).to have_field('status', with: 'cancelled')
 
-    select 'In Progress', from: 'status'
-    click_button('Update Invoice Status')
+        select 'In Progress', from: 'status'
+        click_button('Update Invoice Status')
 
-    expect(current_path).to eq(admin_invoice_path(invoice_1.id))
-    expect(page).to have_field('status', with: 'in progress')
+        expect(current_path).to eq(admin_invoice_path(invoice_1.id))
+        expect(page).to have_field('status', with: 'in progress')
 
-    select 'Completed', from: 'status'
-    click_button('Update Invoice Status')
+        select 'Completed', from: 'status'
+        click_button('Update Invoice Status')
 
-    expect(current_path).to eq(admin_invoice_path(invoice_1.id))
-    expect(page).to have_field('status', with: 'completed')
-  end
+        expect(current_path).to eq(admin_invoice_path(invoice_1.id))
+        expect(page).to have_field('status', with: 'completed')
+      end
+    end
 
-  scenario 'admin sees total revenue generated from this invoice' do
-    expect(page).to have_content(invoice_1.invoice_items.revenue.to_f/100)
+    context 'admin sees section for total revenue' do
+      scenario 'admin sees total revenue generated from this invoice' do
+        expect(page).to have_content(invoice_1.invoice_items.revenue.to_f/100)
+      end
+    end
+
+    context 'admin sees section for total discounted revenue' do
+      scenario 'displays total discounted revenue for this invoice including the bulk discounts calculation' do
+        merchant_3 = Merchant.create!(name: 'Ron Swanson', status: 0)
+        merchant_4 = Merchant.create!(name: 'Mike Cheney', status: 0)
+
+        item_5 = merchant_3.items.create!(name: "Necklace", description: "A thing around your neck", unit_price: 2000, status: 0)
+        item_6 = merchant_3.items.create!(name: "Bracelet", description: "A thing around your wrist", unit_price: 900, status: 0)
+        item_7 = merchant_4.items.create!(name: "Earrings", description: "These go through your ears", unit_price: 1500, status: 1)
+
+        customer_2 = Customer.create!(first_name: "Billy", last_name: "Joel")
+
+        invoice_4 = customer_2.invoices.create!(status: 1, created_at: '2012-03-25 09:54:09')
+
+        invoice_item_6 = InvoiceItem.create!(item_id: item_5.id, invoice_id: invoice_4.id, unit_price: item_5.unit_price, quantity: 2, status: 0)
+        invoice_item_7 = InvoiceItem.create!(item_id: item_6.id, invoice_id: invoice_4.id, unit_price: item_6.unit_price, quantity: 26, status: 0)
+        invoice_item_8 = InvoiceItem.create!(item_id: item_7.id, invoice_id: invoice_4.id, unit_price: item_7.unit_price, quantity: 6, status: 0)
+
+        bulk_discount_1 = merchant_3.bulk_discounts.create!(name: "Ten off Ten", threshold: 10, percent_discount: 10)
+        bulk_discount_2 = merchant_4.bulk_discounts.create!(name: "Five off Five", threshold: 5, percent_discount: 5)
+
+        visit admin_invoice_path(invoice_4.id)
+
+        expect(page).to have_content((invoice_4.invoice_items.revenue.to_f/100) - (invoice_4.total_invoice_discounts.to_f/100))
+      end
+    end
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -154,7 +154,6 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
     end
 
     scenario 'next to each invoice item I see a link to the bulk discount show page that was applied if any' do
-      save_and_open_page
       within "#item#{item_1.id}" do
         expect(page).to have_link(bulk_discount_1.name, href: merchant_bulk_discount_path(merchant_1.id, bulk_discount_1.id))
         expect(page).to have_no_content('None')

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -166,10 +166,4 @@ RSpec.describe 'Merchant Invoice Show Page', type: :feature do
       end
     end
   end
-
-#   No. 8 Merchant Invoice Show Page: Link to applied discounts
-#
-# As a merchant
-# When I visit my merchant invoice show page
-# Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -98,11 +98,37 @@ RSpec.describe Invoice do
         invoice_item_8 = InvoiceItem.create!(quantity: 10, unit_price: item_7.unit_price, item_id: item_7.id, invoice_id: invoice_4.id, status: 0)
 
         bulk_discount_1 = merchant_3.bulk_discounts.create!(name: "Ten off Ten", threshold: 10, percent_discount: 10)
-        bulk_discount_1 = merchant_4.bulk_discounts.create!(name: "Ten off Ten", threshold: 10, percent_discount: 10)
+        bulk_discount_2 = merchant_4.bulk_discounts.create!(name: "Five off Five", threshold: 5, percent_discount: 5)
 
         total_discount = invoice_item_6.unit_price * invoice_item_6.quantity * (bulk_discount_1.percent_discount / 100.00)
 
         expect(invoice_4.total_discounts_by_merchant(merchant_3.id)).to eq(total_discount)
+      end
+    end
+
+    describe '#total_invoice_discounts' do
+      it 'returns the discounted value of all invoice items with discounts on an invoice' do
+        merchant_3 = Merchant.create!(name: 'Ron Swanson', status: 0)
+        merchant_4 = Merchant.create!(name: 'Mike Cheney', status: 0)
+
+        item_5 = merchant_3.items.create!(name: "Necklace", description: "A thing around your neck", unit_price: 2000, status: 0)
+        item_6 = merchant_3.items.create!(name: "Bracelet", description: "A thing around your wrist", unit_price: 900, status: 0)
+        item_7 = merchant_4.items.create!(name: "Earrings", description: "These go through your ears", unit_price: 1500, status: 1)
+
+        customer_2 = Customer.create!(first_name: "Billy", last_name: "Joel")
+
+        invoice_4 = customer_2.invoices.create!(status: 1, created_at: '2012-03-25 09:54:09')
+
+        invoice_item_6 = InvoiceItem.create!(item_id: item_5.id, invoice_id: invoice_4.id, unit_price: item_5.unit_price, quantity: 2, status: 0)
+        invoice_item_7 = InvoiceItem.create!(item_id: item_6.id, invoice_id: invoice_4.id, unit_price: item_6.unit_price, quantity: 26, status: 0)
+        invoice_item_8 = InvoiceItem.create!(item_id: item_7.id, invoice_id: invoice_4.id, unit_price: item_7.unit_price, quantity: 6, status: 0)
+
+        bulk_discount_1 = merchant_3.bulk_discounts.create!(name: "Ten off Ten", threshold: 10, percent_discount: 10)
+        bulk_discount_2 = merchant_4.bulk_discounts.create!(name: "Five off Five", threshold: 5, percent_discount: 5)
+
+        total_discounts_invoice_4 = (invoice_item_7.unit_price * invoice_item_7.quantity * (bulk_discount_1.percent_discount / 100.00)) + (invoice_item_8.unit_price * invoice_item_8.quantity * (bulk_discount_2.percent_discount / 100.00)).to_f
+
+        expect(invoice_4.total_invoice_discounts).to eq(total_discounts_invoice_4.to_f)
       end
     end
   end


### PR DESCRIPTION
Features:
- Admin invoice show page displays total revenue and total discounted revenue

Models:
- Add #total_invoice_discounts to invoice model: returns the total discounts of all invoice_items on an invoice (this method does not sort discounted revenue by merchant)

Updates:
- Comment out application controller method that calls github facade. GitHub API functionality currently not-employed

Tests:
- Feature tests in admin/invoices/show_spec.rb cover display of discounted revenue on page
- Model test cover new #total_invoice_discounts behavior
- Feature tests: 100.00% coverage (commented out unused github facade code in application controller)
- Model tests: 100.00% coverage