### PR TITLE
Merchant Discounts Index Page: Use API to display next three US holidays and dates

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,4 +1,5 @@
 class BulkDiscountsController < ApplicationController
+  before_action :holiday_facade, only: [:index]
 
   def index
     @merchant = Merchant.find(params[:merchant_id])
@@ -42,5 +43,9 @@ class BulkDiscountsController < ApplicationController
 
   def bulk_discount_params
     params.require(:bulk_discount).permit(:name, :threshold, :percent_discount)
+  end
+
+  def holiday_facade
+    @holiday_facade = HolidayFacade.new
   end
 end

--- a/app/facades/holiday_facade.rb
+++ b/app/facades/holiday_facade.rb
@@ -1,0 +1,18 @@
+class HolidayFacade
+  attr_reader :service,
+              :holidays
+
+  def initialize
+    @service = service
+  end
+
+  def holidays
+    @_holidays ||= service.next_365_us_holidays.map do |data|
+      Holiday.new(data)
+    end
+  end
+
+  def service
+    @_service ||= HolidayService.new
+  end
+end

--- a/app/poros/holiday.rb
+++ b/app/poros/holiday.rb
@@ -1,0 +1,10 @@
+class Holiday
+
+  attr_reader :name,
+              :date
+
+  def initialize(data)
+    @name = data[:localName]
+    @date = data[:date]
+  end
+end

--- a/app/services/holiday_service.rb
+++ b/app/services/holiday_service.rb
@@ -1,0 +1,13 @@
+class HolidayService
+
+  def next_365_us_holidays
+    get_url("https://date.nager.at/api/v2/NextPublicHolidays/us")
+  end
+
+  def get_url(url)
+    response = HTTParty.get(url)
+
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -2,7 +2,8 @@
 <head>
   <style>
     #holidays {
-      position: absolute;
+      position: relative;
+      float: right;
       top: 80px;
       right: 0;
       border: 3px solid black;
@@ -16,6 +17,9 @@
 <body>
 
   <h1>Bulk Discounts Index</h1>
+  <div style="text-align: right; top:-10px;font-size:100%;">
+    <%= render partial: '/layouts/partials/merchant_dashboard_links' %> <%= link_to 'Discounts', merchant_bulk_discounts_path(@merchant.id) %><br>
+  </div>
 
   <div id="holidays">
     <h3>Upcoming Holidays:</h3>

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,14 +1,41 @@
-<h1>Bulk Discounts Index</h1>
+<html>
+<head>
+  <style>
+    #holidays {
+      position: absolute;
+      top: 80px;
+      right: 0;
+      border: 3px solid black;
+      padding: 15px;
+      background-color: gray;
+      opacity: 0.7;
+    }
+  </style>
+</head>
 
-<%= link_to 'Create New Discount', new_merchant_bulk_discount_path(@merchant.id) %>
+<body>
 
-<% @bulk_discounts.each do |bd| %>
-  <div id="bulk-discount-<%= bd.id %>">
-    <h3><%= link_to bd.name, merchant_bulk_discount_path(@merchant.id, bd.id) %></h3>
-    <ul>
-      <li>Threshold: <%= bd.threshold %></li>
-      <li>Percent Discount: <%= bd.percent_discount %></li>
-    </ul>
-    <%= link_to 'Delete Discount', merchant_bulk_discount_path(@merchant.id, bd.id), method: :delete %>
+  <h1>Bulk Discounts Index</h1>
+
+  <div id="holidays">
+    <h3>Upcoming Holidays:</h3>
+    <% @holiday_facade.holidays.first(3).each do |holiday| %>
+      <p> <%= holiday.name %> - <%= holiday.date %></p>
+    <% end %>
   </div>
-<% end %>
+
+  <%= link_to 'Create New Discount', new_merchant_bulk_discount_path(@merchant.id) %>
+
+  <% @bulk_discounts.each do |bd| %>
+    <div id="bulk-discount-<%= bd.id %>">
+      <h3><%= link_to bd.name, merchant_bulk_discount_path(@merchant.id, bd.id) %></h3>
+      <ul>
+        <li>Threshold: <%= bd.threshold %></li>
+        <li>Percent Discount: <%= bd.percent_discount %></li>
+      </ul>
+      <%= link_to 'Delete Discount', merchant_bulk_discount_path(@merchant.id, bd.id), method: :delete %>
+    </div>
+  <% end %>
+
+</body>
+</html>

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -109,7 +109,6 @@ RSpec.describe 'Merchant Bulk Discounts Index Page', type: :feature do
 
     context 'I see an upcoming holidays section' do
       scenario 'and i see the name and date of the next 3 upcoming holidays' do
-        save_and_open_page
         expect(page).to have_content("Upcoming Holidays:")
 
         within "#holidays" do

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe 'Merchant Bulk Discounts Index Page', type: :feature do
   let!(:twenty_off_fifteen) {merchant_1.bulk_discounts.create!(name: "Twenty Off Fifteen", threshold: 15, percent_discount: 20)}
   let!(:five_off_ten) {merchant_2.bulk_discounts.create!(name: "Five Off Ten", threshold: 10, percent_discount: 5)}
 
-  before(:each) do
-    stub_request(:any, "https://date.nager.at/api/v2/NextPublicHolidays/us").to_return(body: File.read('./spec/support/holiday_api_response/holiday_next_365_day_repsonse.json'), status: 200)
-  end
-
   context 'As a merchant when I visit my dashboard' do
     scenario 'I see a link to view my discounts' do
       visit merchant_dashboard_index_path(merchant_1.id)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,8 @@ RSpec.configure do |config|
     stub_request(:any, "https://api.github.com/repos/Sierra-T-9598/little-esty-shop/commits?per_page=100").to_return(body: File.read('./tmp/github_commits_response_body.txt'), status: 200)
     ## Pull Requests
     stub_request(:any, "https://api.github.com/repos/Sierra-T-9598/little-esty-shop/pulls?state=closed&per_page=100").to_return(body: File.read('./tmp/github_pull_requests_response_body.txt'), status: 200)
+
+    stub_request(:any, "https://date.nager.at/api/v2/NextPublicHolidays/us").to_return(body: File.read('./spec/support/holiday_api_response/holiday_next_365_day_repsonse.json'), status: 200)
   end
 
   # You can uncomment this line to turn off ActiveRecord support entirely.

--- a/spec/support/holiday_api_response/holiday_next_365_day_repsonse.json
+++ b/spec/support/holiday_api_response/holiday_next_365_day_repsonse.json
@@ -1,0 +1,204 @@
+[
+  {
+    "date": "2022-02-21",
+    "localName": "Presidents Day",
+    "name": "Washington's Birthday",
+    "countryCode": "US",
+    "fixed": false,
+    "global": true,
+    "counties": null,
+    "launchYear": null,
+    "types": [
+      "Public"
+    ]
+  },
+  {
+    "date": "2022-04-15",
+    "localName": "Good Friday",
+    "name": "Good Friday",
+    "countryCode": "US",
+    "fixed": false,
+    "global": false,
+    "counties": [
+      "US-CT",
+      "US-DE",
+      "US-HI",
+      "US-IN",
+      "US-KY",
+      "US-LA",
+      "US-NC",
+      "US-ND",
+      "US-NJ",
+      "US-TN"
+    ],
+    "launchYear": null,
+    "types": [
+      "Public"
+    ]
+  },
+  {
+    "date": "2022-05-30",
+    "localName": "Memorial Day",
+    "name": "Memorial Day",
+    "countryCode": "US",
+    "fixed": false,
+    "global": true,
+    "counties": null,
+    "launchYear": null,
+    "types": [
+      "Public"
+    ]
+  },
+  {
+    "date": "2022-06-20",
+    "localName": "Juneteenth",
+    "name": "Juneteenth",
+    "countryCode": "US",
+    "fixed": false,
+    "global": true,
+    "counties": null,
+    "launchYear": 2021,
+    "types": [
+      "Public"
+    ]
+  },
+  {
+    "date": "2022-07-04",
+    "localName": "Independence Day",
+    "name": "Independence Day",
+    "countryCode": "US",
+    "fixed": false,
+    "global": true,
+    "counties": null,
+    "launchYear": null,
+    "types": [
+      "Public"
+    ]
+  },
+  {
+    "date": "2022-09-05",
+    "localName": "Labor Day",
+    "name": "Labour Day",
+    "countryCode": "US",
+    "fixed": false,
+    "global": true,
+    "counties": null,
+    "launchYear": null,
+    "types": [
+      "Public"
+    ]
+  },
+  {
+    "date": "2022-10-10",
+    "localName": "Columbus Day",
+    "name": "Columbus Day",
+    "countryCode": "US",
+    "fixed": false,
+    "global": false,
+    "counties": [
+      "US-AL",
+      "US-AZ",
+      "US-CO",
+      "US-CT",
+      "US-DC",
+      "US-GA",
+      "US-ID",
+      "US-IL",
+      "US-IN",
+      "US-IA",
+      "US-KS",
+      "US-KY",
+      "US-LA",
+      "US-ME",
+      "US-MD",
+      "US-MA",
+      "US-MS",
+      "US-MO",
+      "US-MT",
+      "US-NE",
+      "US-NH",
+      "US-NJ",
+      "US-NM",
+      "US-NY",
+      "US-NC",
+      "US-OH",
+      "US-OK",
+      "US-PA",
+      "US-RI",
+      "US-SC",
+      "US-TN",
+      "US-UT",
+      "US-VA",
+      "US-WV"
+    ],
+    "launchYear": null,
+    "types": [
+      "Public"
+    ]
+  },
+  {
+    "date": "2022-11-11",
+    "localName": "Veterans Day",
+    "name": "Veterans Day",
+    "countryCode": "US",
+    "fixed": false,
+    "global": true,
+    "counties": null,
+    "launchYear": null,
+    "types": [
+      "Public"
+    ]
+  },
+  {
+    "date": "2022-11-24",
+    "localName": "Thanksgiving Day",
+    "name": "Thanksgiving Day",
+    "countryCode": "US",
+    "fixed": false,
+    "global": true,
+    "counties": null,
+    "launchYear": 1863,
+    "types": [
+      "Public"
+    ]
+  },
+  {
+    "date": "2022-12-26",
+    "localName": "Christmas Day",
+    "name": "Christmas Day",
+    "countryCode": "US",
+    "fixed": false,
+    "global": true,
+    "counties": null,
+    "launchYear": null,
+    "types": [
+      "Public"
+    ]
+  },
+  {
+    "date": "2023-01-02",
+    "localName": "New Year's Day",
+    "name": "New Year's Day",
+    "countryCode": "US",
+    "fixed": false,
+    "global": true,
+    "counties": null,
+    "launchYear": null,
+    "types": [
+      "Public"
+    ]
+  },
+  {
+    "date": "2023-01-16",
+    "localName": "Martin Luther King, Jr. Day",
+    "name": "Martin Luther King, Jr. Day",
+    "countryCode": "US",
+    "fixed": false,
+    "global": true,
+    "counties": null,
+    "launchYear": null,
+    "types": [
+      "Public"
+    ]
+  }
+]


### PR DESCRIPTION
Feature:
- Merchant discounts index page displays the names of next three US holidays and their dates

Updates:
- Add API data flow to generate holidays: HolidayService, HolidayFacade, Holiday(poros)
- Call HolidayFacade in bulk_discounts controller and use callback to render it available in the Index action

Tests:
- Bulk discounts index spec covers presence of next three holiday names
- Tests check that only three names are displayed and fourth is not
- Stub API request for Holidays in rails_helper
- Feature Tests: 100.00% coverage
- Models Tests: 100.00% coverage