### PR TITLE
Bulk Discounts Index: Holiday Discounts Extension

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -4,6 +4,7 @@ class BulkDiscountsController < ApplicationController
   def index
     @merchant = Merchant.find(params[:merchant_id])
     @bulk_discounts = BulkDiscount.where(merchant_id: params[:merchant_id])
+    @holiday_bulk_discounts = HolidayBulkDiscount.where(merchant_id: params[:merchant_id])
   end
 
   def show
@@ -19,7 +20,7 @@ class BulkDiscountsController < ApplicationController
 
     redirect_to merchant_bulk_discounts_path(merchant.id)
   end
-  
+
   def edit
     @bulk_discount = BulkDiscount.find(params[:id])
     @merchant = Merchant.find(params[:merchant_id])

--- a/app/controllers/holiday_bulk_discounts_controller.rb
+++ b/app/controllers/holiday_bulk_discounts_controller.rb
@@ -1,0 +1,20 @@
+class HolidayBulkDiscountsController < ApplicationController
+
+  def new
+    @holiday_name = params[:holiday_name]
+  end
+
+  def create
+    merchant = Merchant.find(params[:merchant_id])
+    holiday_discount = merchant.holiday_bulk_discounts.create(holiday_discount_params)
+
+    redirect_to merchant_bulk_discounts_path
+  end
+
+  private
+
+  def holiday_discount_params
+    params.require(:holiday_bulk_discount).permit(:name, :threshold, :percent_discount, :holiday)
+  end
+
+end

--- a/app/models/holiday_bulk_discount.rb
+++ b/app/models/holiday_bulk_discount.rb
@@ -1,0 +1,7 @@
+class HolidayBulkDiscount < BulkDiscount
+
+  def self.existing_holiday_discounts
+    pluck(:holiday)
+    .uniq
+  end
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -7,6 +7,7 @@ class Merchant < ApplicationRecord
   has_many :transactions, through: :invoices
   has_many :customers, through: :invoices
   has_many :bulk_discounts
+  has_many :holiday_bulk_discounts
 
   validates_presence_of :name
 

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -2,44 +2,66 @@
 <head>
   <style>
     #holidays {
-      position: relative;
       float: right;
+      width: 45%;
       top: 80px;
       right: 0;
       border: 3px solid black;
       padding: 15px;
       background-color: gray;
-      opacity: 0.7;
+    }
+
+    #all-discounts {
+      float: left;
+      width: 45%;
+      top: 80px;
+      border: 3px solid black;
+      padding: 15px;
+      background-color: gray;
     }
   </style>
 </head>
 
 <body>
 
-  <h1>Bulk Discounts Index</h1>
   <div style="text-align: right; top:-10px;font-size:100%;">
     <%= render partial: '/layouts/partials/merchant_dashboard_links' %> <%= link_to 'Discounts', merchant_bulk_discounts_path(@merchant.id) %><br>
   </div>
 
-  <div id="holidays">
-    <h3>Upcoming Holidays:</h3>
-    <% @holiday_facade.holidays.first(3).each do |holiday| %>
-      <p> <%= holiday.name %> - <%= holiday.date %></p>
+  <h1>Bulk Discounts Index</h1>
+
+  <p><%= link_to 'Create New Discount', new_merchant_bulk_discount_path(@merchant.id) %></p>
+
+  <div id="all-discounts">
+    <h2>Normal Discounts:</h2>
+    <% @bulk_discounts.each do |bd| %>
+      <div id="bulk-discount-<%= bd.id %>">
+        <h3><%= link_to bd.name, merchant_bulk_discount_path(@merchant.id, bd.id) %></h3>
+        <ul>
+          <li>Threshold: <%= bd.threshold %></li>
+          <li>Percent Discount: <%= bd.percent_discount %></li>
+        </ul>
+        <%= link_to 'Delete Discount', merchant_bulk_discount_path(@merchant.id, bd.id), method: :delete %>
+      </div>
     <% end %>
   </div>
 
-  <%= link_to 'Create New Discount', new_merchant_bulk_discount_path(@merchant.id) %>
-
-  <% @bulk_discounts.each do |bd| %>
-    <div id="bulk-discount-<%= bd.id %>">
-      <h3><%= link_to bd.name, merchant_bulk_discount_path(@merchant.id, bd.id) %></h3>
-      <ul>
-        <li>Threshold: <%= bd.threshold %></li>
-        <li>Percent Discount: <%= bd.percent_discount %></li>
-      </ul>
-      <%= link_to 'Delete Discount', merchant_bulk_discount_path(@merchant.id, bd.id), method: :delete %>
+  <div id="holidays">
+    <div id="holiday-discounts">
+      <h2>Holiday Discounts:</h2>
+      <h3>Upcoming Holidays:</h3>
+      <% @holiday_facade.holidays.first(3).each do |holiday| %>
+        <% if @holiday_bulk_discounts.existing_holiday_discounts.include?(holiday.name) %>
+          <div id="holiday-discounts-<%= holiday.date %>">
+            <p> <%= holiday.name %> <%= link_to "View Holiday Discount", merchant_bulk_discount_path(@merchant.id, HolidayBulkDiscount.find_by(holiday: holiday.name).id), method: :get, local: true %> </p>
+          </div>
+        <% else %>
+          <div id="holiday-discounts-<%= holiday.date %>">
+            <p> <%= holiday.name %> - <%= button_to "Create Discount", new_merchant_holiday_bulk_discount_path(@merchant.id), method: :get, params: {holiday_name: holiday.name}, local: true, display: 'inline' %> </p>
+          </div>
+        <% end %>
+      <% end %><br><br>
     </div>
-  <% end %>
-
+  </div>
 </body>
 </html>

--- a/app/views/holiday_bulk_discounts/new.html.erb
+++ b/app/views/holiday_bulk_discounts/new.html.erb
@@ -1,0 +1,16 @@
+<h1>Create New Holiday Bulk Discount</h1>
+
+<%= form_with model: [:merchant, HolidayBulkDiscount.new], local: true do |f| %>
+  <%= f.hidden_field :holiday, value: @holiday_name%>
+
+  <%= f.label :name, "Discount Name" %>
+  <%= f.text_field :name, required: :true, value: "#{@holiday_name} Discount" %><br>
+
+  <%= f.label :percent_discount, 'Percentage Discount' %>
+  <%= f.number_field :percent_discount, in: 1..100, required: :true, value: 30 %><br>
+
+  <%= f.label :threshold, "Quantity Threshold" %>
+  <%= f.number_field :threshold, required: :true, value: 2 %><br>
+
+  <%= f.submit 'Create Holiday Discount' %><br>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,6 @@ Rails.application.routes.draw do
     resources :invoices, only: [:index, :show, :update]
     resources :dashboard, only: [:index]
     resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy, :edit, :update]
+    resources :holiday_bulk_discounts, only: [:new, :create]
   end
 end

--- a/db/migrate/20220118223751_add_type_to_bulk_discounts.rb
+++ b/db/migrate/20220118223751_add_type_to_bulk_discounts.rb
@@ -1,0 +1,5 @@
+class AddTypeToBulkDiscounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bulk_discounts, :type, :string
+  end
+end

--- a/db/migrate/20220118235757_add_holiday_to_bulk_discounts.rb
+++ b/db/migrate/20220118235757_add_holiday_to_bulk_discounts.rb
@@ -1,0 +1,5 @@
+class AddHolidayToBulkDiscounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bulk_discounts, :holiday, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_15_210229) do
+ActiveRecord::Schema.define(version: 2022_01_18_235757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 2022_01_15_210229) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "percent_discount"
+    t.string "type"
+    t.string "holiday"
     t.index ["merchant_id"], name: "index_bulk_discounts_on_merchant_id"
   end
 

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -101,6 +101,123 @@ RSpec.describe 'Merchant Bulk Discounts Index Page', type: :feature do
         expect(page).to have_no_content(fifteen_off_ten.name)
         expect(page).to have_no_content(twenty_off_fifteen.name)
       end
+
+      context 'Holiday Discounts' do
+        scenario 'I see a holiday discounts section' do
+          within "#holiday-discounts" do
+            expect(page).to have_content("Holiday Discounts")
+          end
+        end
+
+        scenario 'I see a Create Discount button next to each of the three upcoming holidays' do
+          within "#holiday-discounts" do
+            within "#holiday-discounts-2022-02-21" do
+              expect(page).to have_content("Presidents Day")
+              expect(page).to have_button("Create Discount")
+            end
+
+            within "#holiday-discounts-2022-04-15" do
+              expect(page).to have_content("Good Friday")
+              expect(page).to have_button("Create Discount")
+            end
+
+            within "#holiday-discounts-2022-05-30" do
+              expect(page).to have_content("Memorial Day")
+              expect(page).to have_button("Create Discount")
+            end
+          end
+        end
+
+        scenario 'When I click the button I am taken to a new discounts form with fields autopopulated' do
+          within "#holiday-discounts-2022-02-21" do
+            click_button "Create Discount"
+          end
+
+          expect(current_path).to eq(new_merchant_holiday_bulk_discount_path(merchant_1.id))
+
+          expect(page).to have_field("Discount Name", with: "Presidents Day Discount")
+          expect(page).to have_field("Percentage Discount", with: "30")
+          expect(page).to have_field("Quantity Threshold", with: "2")
+        end
+
+        scenario 'The form can be submitted as is' do
+          within "#holiday-discounts-2022-02-21" do
+            click_button "Create Discount"
+          end
+
+          click_button "Create Holiday Discount"
+
+          within "#all-discounts" do
+            expect(page).to have_content('Presidents Day Discount')
+          end
+        end
+
+        scenario 'The form can be altered and submitted' do
+          within "#holiday-discounts-2022-02-21" do
+            click_button "Create Discount"
+          end
+
+          fill_in "Discount Name", with: "Perzy Dent Day Sale"
+          fill_in "Percentage Discount", with: "20"
+          fill_in "Quantity Threshold", with: "10"
+
+          click_button "Create Holiday Discount"
+
+          within "#all-discounts" do
+            expect(page).to have_link("Perzy Dent Day Sale")
+
+            click_link "Perzy Dent Day Sale"
+          end
+
+          expect(page).to have_content(20)
+          expect(page).to have_content(10)
+        end
+
+        scenario 'The form redirects to the index page and displays the newly created discount' do
+          within "#holiday-discounts-2022-02-21" do
+            click_button "Create Discount"
+          end
+
+          click_button "Create Holiday Discount"
+
+          expect(current_path).to eq(merchant_bulk_discounts_path(merchant_1.id))
+        end
+
+        scenario 'If I input invalid data into the form, it will not persist to the database' do
+          # Sadpath Testing
+          within "#holiday-discounts-2022-02-21" do
+            click_button "Create Discount"
+          end
+
+          fill_in "Discount Name", with: "Perzy Dent Day Sale"
+          fill_in "Percentage Discount", with: "150"
+
+          click_button "Create Holiday Discount"
+
+          within "#holiday-discounts" do
+            expect(page).to have_no_content("Perzy Dent Day Sale")
+          end
+        end
+
+        scenario 'After creating a discount for that holiday I see a view discount link instead of create discount button' do
+          within "#holiday-discounts-2022-02-21" do
+            click_button "Create Discount"
+          end
+
+          fill_in "Discount Name", with: "Perzy Dent Day Sale"
+
+          click_button "Create Holiday Discount"
+
+          within "#holiday-discounts" do
+            expect(page).to have_link("View Holiday Discount")
+            click_link "View Holiday Discount"
+          end
+
+          expect(page).to have_content("Perzy Dent Day Sale")
+          expect(page).to have_content("Quantity Threshold: 2")
+          expect(page).to have_content("Percentage Discount: 30")
+        end
+      end
     end
 
     context 'I see an upcoming holidays section' do

--- a/spec/models/holiday_bulk_discount_spec.rb
+++ b/spec/models/holiday_bulk_discount_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe HolidayBulkDiscount, type: :model do
+  describe 'relationships' do
+    it { should belong_to(:merchant) }
+    it { should have_many(:items).through(:merchant) }
+    it { should have_many(:invoice_items).through(:items) }
+    it { should have_many(:invoices).through(:merchant) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:percent_discount) }
+    it { should validate_presence_of(:threshold) }
+
+    it { should validate_numericality_of(:percent_discount).is_greater_than(0).is_less_than_or_equal_to(100) }
+    it { should validate_numericality_of(:threshold) }
+  end
+
+  describe 'Class Methods' do
+    describe '::existing_holiday_discounts' do
+      it 'returns a unique array of holiday names for holiday_bulk_discounts' do
+        merchant_1 = Merchant.create!(name: 'Ron Swanson')
+        merchant_2 = Merchant.create!(name: 'Bella Donna')
+
+        holiday_bulk_discount_1 = merchant_1.holiday_bulk_discounts.create!(name: "Presidents Day", threshold: 10, percent_discount: 15, holiday: 'Presidents Day')
+        holiday_bulk_discount_2 = merchant_1.holiday_bulk_discounts.create!(name: "Memorial Day", threshold: 20, percent_discount: 10, holiday: 'Memorial Day')
+        holiday_bulk_discount_3 = merchant_2.holiday_bulk_discounts.create!(name: "Juneteenth", threshold: 20, percent_discount: 10, holiday: 'Juneteenth')
+        holiday_bulk_discount_4 = merchant_2.holiday_bulk_discounts.create!(name: "Presidents Day", threshold: 20, percent_discount: 10, holiday: 'Presidents Day')
+
+        expect(HolidayBulkDiscount.existing_holiday_discounts).to eq(['Presidents Day', 'Memorial Day', 'Juneteenth'])
+      end
+    end
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Merchant do
     it { should have_many(:invoices).through(:invoice_items) }
     it { should have_many(:customers).through(:invoices) }
     it { should have_many(:bulk_discounts) }
+    it { should have_many(:holiday_bulk_discounts) }
   end
 
   describe 'validations' do


### PR DESCRIPTION
Features:
- Bulk_discounts index page displays upcoming three US holidays
- Next to each holiday is a button to create a discount for that holiday
- Clicking that button takes you to a pre-filled, editable form to create a new discount
- When created the discount is added to the index of discounts, then the holiday no longer displays a button to create a discount
- Instead, there is a link to the show page of the holiday discount

Updates/Additions:
- Add holiday_bulk_discounts which inherits from bulk_discounts
- Add relationships
- Add migrations for bulk_discounts `type` column and `holiday` column
- Create holiday_bulk_discounts method that generates a unique array of holiday names that have been used to make a discount
- Update merchant bulk discounts index page css

Tests:
- Bulk discounts index spec: testing added to cover new functionality and content display
- Holiday bulk discounts new/create functionality tested in holiday_bulk_discounts/index_spec
- Model tests to cover new relationships and holiday_bulk_index class method
- Feature Tests: 100.00% coverage
- Model Tests: 100.00% coverage